### PR TITLE
Make wait_for_db more verbose

### DIFF
--- a/scripts/wait_for_db.sh
+++ b/scripts/wait_for_db.sh
@@ -15,5 +15,7 @@ while True:
     except MySQLdb.OperationalError as err:
         if err.args[0] == ${EXPECTED_ERROR_CODE}:
             break
+        else:
+            print(err)
     sleep(1)
 PYTHON_SCRIPT


### PR DESCRIPTION
Hello!

I came across this project from a post in the Seafile forum, and really appreciate the work done: with this I could progress with my Seafile plans.

I had some initial problems with my database setup which took me a while to understand, as the logging output stopped at `waiting for db`: I assumed the issue was the seafile config, but it turns out was a db problem.

As I understand it, the script enters an infinite loop, but without reading into the functionality this is not easy to know and one might start to instead investigate the problem in other places (like I did).

Adding an else clause will produce an output every second which passes by where an error happens, but not the error which is searched for. Once manually editing the file and adding the below line, I understood the problem and was shown an error message along these lines "Can't connect to MySQL server on 'seafile-db' (115)".