### PR TITLE
Make bash shell scripts fail fast to avoid hiding errors

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 echo "Loading environment..."
 set -a
 [ -f .env ] && . .env

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 function print() {
     echo "$(date -Iseconds) [Entrypoint] $@"
 }

--- a/scripts/clean_db.sh
+++ b/scripts/clean_db.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 export PYTHONPATH=${PYTHONPATH}:/opt/seafile/seafile-server-${SEAFILE_SERVER_VERSION}/seahub/thirdpart
 
 CCNET_DB=${CCNET_DB:=ccnet_db}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 function print() {
     echo "$(date -Iseconds) [Init] $@"
 }

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 function print() {
     echo "$(date -Iseconds) [Launch] $@"
 }

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 function print() {
     echo "$(date -Iseconds) [Update] $@"
 }

--- a/scripts/wait_for_db.sh
+++ b/scripts/wait_for_db.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 EXPECTED_ERROR_CODE=1045
 
 export PYTHONPATH=${PYTHONPATH}:/opt/seafile/seafile-server-${SEAFILE_SERVER_VERSION}/seahub/thirdpart

--- a/scripts/write_config.sh
+++ b/scripts/write_config.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 CONFIG_DIR="./conf"
 CCNET_CONFIG_FILE="$CONFIG_DIR/ccnet.conf"
 GUNICORN_CONFIG_FILE="$CONFIG_DIR/gunicorn.conf.py"


### PR DESCRIPTION
 deliberately cause your script to fail, if  certain common errors are detected.

This is using the same config as the Docker Official Image for golang to all bash scripts.

There are different opinions which exact flags to set, but if this is good enough for the official golang image, it sure is good enough for us.

 https://github.com/docker-library/golang/blob/master/update.sh

There are some articles about this:

* https://linuxtect.com/make-bash-shell-safe-with-set-euxo-pipefail/
* https://gist.github.com/usametov/a134115a0fa1157b45ea5d432510d2f6
* https://explainshell.com/explain?cmd=set%20-euxo%20pipefail