### PR TITLE
Follow shellcheck advices for parameters

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function print() {
-    echo "$(date -Iseconds) [Entrypoint] $@"
+    echo "$(date -Iseconds) [Entrypoint] $*"
 }
 
 function quit() {

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function print() {
-    echo "$(date -Iseconds) [Init] $@"
+    echo "$(date -Iseconds) [Init] $*"
 }
 
 function detectAutoMode() {

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function print() {
-    echo "$(date -Iseconds) [Launch] $@"
+    echo "$(date -Iseconds) [Launch] $*"
 }
 
 function readCurrentRevision() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function print() {
-    echo "$(date -Iseconds) [Update] $@"
+    echo "$(date -Iseconds) [Update] $*"
 }
 
 function update_db() {


### PR DESCRIPTION
shellcheck, one of the bigger bash shell linters, complained about the usage of `$@`.

According to the below rule, `$*` is better.

I dont know how to reliably verify that everything still works, but did some initial testing and it seems to work as before.

https://github.com/koalaman/shellcheck/wiki/SC2145