### PR TITLE
Bash: Quote all variables as to prevent globbing and word splitting

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -33,7 +33,7 @@ done
 if DOCKERFILE_DIR=""; then DOCKERFILE_DIR="."; fi
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 
 # Register/update emulators
 docker run --rm --privileged tonistiigi/binfmt --install all >/dev/null
@@ -59,8 +59,8 @@ docker buildx use $BUILDER
 
 # Build image
 docker buildx build \
-    --build-arg REVISION=$REVISION \
-    --build-arg SEAFILE_SERVER_VERSION=$SEAFILE_SERVER_VERSION \
-    --build-arg PYTHON_REQUIREMENTS_URL_SEAHUB=$PYTHON_REQUIREMENTS_URL_SEAHUB \
-    --build-arg PYTHON_REQUIREMENTS_URL_SEAFDAV=$PYTHON_REQUIREMENTS_URL_SEAFDAV \
-    $OUTPUT --platform "$MULTIARCH_PLATFORMS" $TAGS "$DOCKERFILE_DIR"
+    --build-arg REVISION="$REVISION" \
+    --build-arg SEAFILE_SERVER_VERSION="$SEAFILE_SERVER_VERSION" \
+    --build-arg PYTHON_REQUIREMENTS_URL_SEAHUB="$PYTHON_REQUIREMENTS_URL_SEAHUB" \
+    --build-arg PYTHON_REQUIREMENTS_URL_SEAFDAV="$PYTHON_REQUIREMENTS_URL_SEAFDAV" \
+    $OUTPUT --platform "$MULTIARCH_PLATFORMS" "$TAGS" "$DOCKERFILE_DIR"

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -40,16 +40,16 @@ function rightsManagement() {
     fi
 
     print "Adjusting identifiers"
-    groupmod -g $PGID seafile
-    usermod -u $PUID seafile
+    groupmod -g "$PGID" seafile
+    usermod -u "$PUID" seafile
 
     dirs=("/shared/conf" "/shared/logs" "/shared/media" "/shared/seafile-data" "/shared/seahub-data" "/shared/sqlite")
-    for dir in ${dirs[@]}
+    for dir in "${dirs[@]}"
     do
-        if [[ -d "$dir" && ("$(stat -c %u $dir)" != $PUID || "$(stat -c %g $dir)" != $PGID) ]]
+        if [[ -d "$dir" && ("$(stat -c %u "$dir")" != $PUID || "$(stat -c %g "$dir")" != $PGID) ]]
         then
             print "Changing owner for $dir"
-            chown -R seafile:seafile $dir
+            chown -R seafile:seafile "$dir"
         fi
     done
 }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -76,11 +76,11 @@ fi
 
 print "Exposing media folder in the volume"
 cp -r ./media /shared/
-ln -s /shared/media ./seafile-server-$SEAFILE_SERVER_VERSION/seahub
+ln -s /shared/media ./seafile-server-"$SEAFILE_SERVER_VERSION"/seahub
 
 print "Running installation script"
 LOGFILE=./install.log
-./seafile-server-$SEAFILE_SERVER_VERSION/setup-seafile$MYSQL.sh $AUTO |& tee $LOGFILE
+./seafile-server-"$SEAFILE_SERVER_VERSION"/setup-seafile$MYSQL.sh "$AUTO" |& tee $LOGFILE
 
 # Handle db starting twice at init edge case 
 if [[ "$AUTO" && ! "$SQLITE" && "$(grep -Pi '(failed)|(error)' $LOGFILE)" ]]
@@ -101,7 +101,7 @@ then
     fi
 
     print "Retrying install"
-    ./seafile-server-$SEAFILE_SERVER_VERSION/setup-seafile-mysql.sh $AUTO | tee $LOGFILE
+    ./seafile-server-"$SEAFILE_SERVER_VERSION"/setup-seafile-mysql.sh "$AUTO" | tee $LOGFILE
 fi
 
 if [ "$(grep -Pi '(failed)|(error)|(missing)' $LOGFILE)" ]
@@ -118,7 +118,7 @@ ln -s ../seahub-data/custom /shared/media
 print "Exposing configuration and data"
 # Use cp and not move for multiple volume mapping compatibility
 cp -r ./conf /shared/ && rm -rf ./conf
-echo $REVISION > /shared/conf/revision
+echo "$REVISION" > /shared/conf/revision
 cp -r ./seafile-data /shared/ && rm -rf ./seafile-data
 cp -r ./seahub-data /shared/ && rm -rf ./seahub-data
 mkdir /shared/seahub-data/custom
@@ -138,7 +138,7 @@ fi
 if [ ! -d "./seafile-server-latest" ]
 then
     print "Making symlink to latest version"
-    ln -s seafile-server-$SEAFILE_SERVER_VERSION seafile-server-latest
+    ln -s seafile-server-"$SEAFILE_SERVER_VERSION" seafile-server-latest
 fi
 
 if [ ! -d "./conf" ]

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -76,7 +76,7 @@ readCurrentRevision
 if [[ $CURRENT_REVISION -lt $REVISION ]]
 then
     print "New image revision, updating..."
-    /home/seafile/update.sh $CURRENT_REVISION
+    /home/seafile/update.sh "$CURRENT_REVISION"
     if [ $? != 0 ]; then exit 1; fi
 fi
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -7,7 +7,7 @@ function print() {
 }
 
 function update_db() {
-    if ! python3 ${INSTALLPATH}/upgrade/db_update_helper.py $1
+    if ! python3 "${INSTALLPATH}"/upgrade/db_update_helper.py "$1"
     then
         print "Failed to update database"
         exit 1
@@ -22,14 +22,14 @@ export SEAFILE_CONF_DIR=${TOPDIR}/seafile-data
 export SEAFILE_CENTRAL_CONF_DIR=${TOPDIR}/conf
 export PYTHONPATH=${INSTALLPATH}/seafile/lib/python3.6/site-packages:${INSTALLPATH}/seafile/lib64/python3.6/site-packages:${INSTALLPATH}/seahub:${INSTALLPATH}/seahub/thirdpart:$PYTHONPATH
 
-if [ $CURRENT_REVISION -lt 1 ]; then
+if [ "$CURRENT_REVISION" -lt 1 ]; then
     if [ ! "$SQLITE" ]; then
         print "Update database to Seafile 8 scheme"
         update_db 8.0.0
     fi
 fi
 
-if [ $CURRENT_REVISION -lt 2 ]; then
+if [ "$CURRENT_REVISION" -lt 2 ]; then
     print "Update database to Seafile 9 scheme"
     update_db 9.0.0
 
@@ -40,5 +40,5 @@ if [ $CURRENT_REVISION -lt 2 ]; then
 fi
 
 
-echo $REVISION > "/shared/conf/revision"
+echo "$REVISION" > "/shared/conf/revision"
 print "Done!"


### PR DESCRIPTION
Review all bash $variable usage and make sure each usage is quoted as to prevent globbing and word splitting.

This is already mostly in place, I just went over all occurrences.

https://github.com/koalaman/shellcheck/wiki/SC2086