### PR TITLE
Bash: Remove SIGKILL trap from docker_entrypoint

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -46,7 +46,7 @@ function rightsManagement() {
     dirs=("/shared/conf" "/shared/logs" "/shared/media" "/shared/seafile-data" "/shared/seahub-data" "/shared/sqlite")
     for dir in "${dirs[@]}"
     do
-        if [[ -d "$dir" && ("$(stat -c %u "$dir")" != $PUID || "$(stat -c %g "$dir")" != $PGID) ]]
+        if [[ -d "$dir" && ("$(stat -c %u "$dir")" != "$PUID" || "$(stat -c %g "$dir")" != "$PGID") ]]
         then
             print "Changing owner for $dir"
             chown -R seafile:seafile "$dir"
@@ -57,7 +57,6 @@ function rightsManagement() {
 # Quit when receiving some signals
 trap quit SIGTERM
 trap quit SIGINT
-trap quit SIGKILL
 
 timezoneAdjustement
 rightsManagement

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -12,7 +12,7 @@ function quit() {
     exit
 }
 
-function timezoneAdjustement() {
+function timezoneAdjustment() {
     if [ "$TZ" ]
     then
         if [ ! -f "/usr/share/zoneinfo/$TZ" ]
@@ -58,7 +58,7 @@ function rightsManagement() {
 trap quit SIGTERM
 trap quit SIGINT
 
-timezoneAdjustement
+timezoneAdjustment
 rightsManagement
 
 if [ ! -d "/shared" ]


### PR DESCRIPTION
It is not possible to trap the SIGKILL signal in a bash script.

https://github.com/koalaman/shellcheck/wiki/SC2173

Also quote last two variables, adjust spelling of TZ function