### PR TITLE
Doc: clarify MYSQL_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ I you want a MySQL/MariaDB deployment, you'll have to/can deal with some additio
 |`MYSQL_HOST`|*(Optional)* Hostname of the MySQL server. It has to be reachable from within the container, using Docker networks is probably the key here. *Default: 127.0.0.1*|
 |`MYSQL_PORT`|*(Optional)* Port of the MySQL server. *Default: 3306*|
 |`USE_EXISTING_DB`|*(Optional)* (0: Create new databases\|1: Use existing ones) Use already created databases or create new ones. Using existing DBs is a **fully untested** option but this is provided by the Seafile installation script. So, well, it's documented here. *Default: 0*|
-|`MYSQL_USER`|*(Optional)* Standard user name. Will be granted admin permissions on all databases below. *Default: seafile*|
+|`MYSQL_USER`|*(Optional)* Standard user name. Will be created and granted admin permissions on all databases below. *Default: seafile*|
 |`MYSQL_USER_PASSWD`|**(Mandatory if `MYSQL_USER` isn't `root`)** Standard user password.|
 |`MYSQL_USER_HOST`|*(Optional)* Authorized host for the standard user. *Default: %*|
 |`MYSQL_ROOT_PASSWD`|**(Mandatory)** Password of the root user. |


### PR DESCRIPTION
From what I can tell, the MySQL standard `seafile` user is created during startup.

This PR adjusts the readme to clarify this.