### PR TITLE
Runtime: Add text editor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-instal
     libtiff5 \
     libxcb1 \
     libfreetype6 \
+    vim \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/seafile


### PR DESCRIPTION
The different configuration adjustments for Seahub, Seafile etc all requires some text editing to be carried out on the system from what I can tell. My suggestion is to include vim as to allow one option present out of the box.

Not sure whats your editor of choice, or if there already is some editor built-in but I could not find one.